### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -1,4 +1,7 @@
 name: Trigger update workflows on all branches
+permissions:
+  contents: read
+  issues: write
 on:
   schedule:
     - cron: '35 10 * * *' # Run at 5:35 AM EST | 10:35 AM UTC (Github Actions runs on UTC, no Daylight Savings Time changes are accounted for in this trigger)


### PR DESCRIPTION
Potential fix for [https://github.com/Operation-P-E-A-C-C-E-Robotics/Operation-P-E-A-C-C-E-Robotics.github.io/security/code-scanning/7](https://github.com/Operation-P-E-A-C-C-E-Robotics/Operation-P-E-A-C-C-E-Robotics.github.io/security/code-scanning/7)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, ensuring that the `GITHUB_TOKEN` has only the necessary access. Based on the workflow's functionality, the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `issues: write` for closing issues.
- Additional permissions can be added if required by specific steps.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
